### PR TITLE
added env.IP for bind server to specifig ip

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -6,6 +6,7 @@ import { getNodeList, listen, Node, Action } from "./discovery";
 
 const HTTPS_PORT = 443;
 const HTTP_PORT = Number(process.env.PORT || 80);
+const HTTP_IP = process.env.IP || '0.0.0.0';
 const SOCKET_TIMEOUT = Number(process.env.SOCKET_TIMEOUT || 30000); // 30 seconds default socket timeout
 
 const processIds: { [id: string]: httpProxy } = {}
@@ -139,15 +140,15 @@ server.on('listening', () => console.debug("@colyseus/proxy listening at", JSON.
  * Create HTTP -> HTTPS redirection server.
  */
 if (server instanceof https.Server) {
-  server.listen(HTTPS_PORT);
+  server.listen(HTTPS_PORT, HTTP_IP);
 
   const httpServer = http.createServer((req, res) => {
     res.writeHead(301, { "Location": "https://" + req.headers['host']! + req.url });
     res.end();
   });
   httpServer.on('listening', () => console.debug("@colyseus/proxy http -> https listening at", 80));
-  httpServer.listen(HTTP_PORT);
+  httpServer.listen(HTTP_PORT, HTTP_IP);
 
 } else {
-  server.listen(HTTP_PORT);
+  server.listen(HTTP_PORT, HTTP_IP);
 }


### PR DESCRIPTION
Hello @endel i add and option for send ip parameter so we can bind the proxy to an specific IP, because for my dedicated server im using main ip for the client with https, so i get error when i try to start the proxy, because the address and the port is in use, i have 6 ips so will be nice to specific an ip for the proxy.