### PR TITLE
Self-cleaning of failed nodes and 503 unavailable status

### DIFF
--- a/discovery.ts
+++ b/discovery.ts
@@ -2,6 +2,7 @@ import Redis from "ioredis";
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
 const NODES_SET = "colyseus:nodes";
+const ROOM_COUNT_KEY = "roomcount";
 const DISCOVERY_CHANNEL = "colyseus:nodes:discovery";
 
 const redis = new Redis(REDIS_URL);
@@ -30,4 +31,10 @@ export function listen(cb: (action: Action, node: Node) => void) {
         const [action, data] = JSON.parse(message).split(",");
         cb(action, parseNode(data));
     });
+}
+
+export async function cleanUpNode(node: Node) {
+    const nodeAddress = `${node.processId}/${node.address}`;
+    await redis.srem(NODES_SET, nodeAddress);
+    await redis.hdel(ROOM_COUNT_KEY, node.processId);
 }


### PR DESCRIPTION
Previously the proxy would stall requests on error or when there are no nodes. This can happen if a node fails to gracefully shutdown or all nodes are down for maintenance or restarting.

This change attempts to detect failed nodes and to make and attempt at unregistering and cleaning up its presence. The request is then re-routed. If there are no nodes, status 503 is returned to prevent blocking the request indefinitely. 

Possible improvements or issues

- Is proxy.on("error") a reliable way to detect a failed node? Legitimate server errors seem to avoid it as expected.
- I regret having to partially duplicate the redis code in cleanUpNode, but could not think of another way 