### PR TITLE
Add validation to prevent multiple deduction

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -82,11 +82,14 @@ function register(node: Node) {
 
 function unregister(node: Node) {
   const proxy = processIds[node.processId];
+  const idx = proxies.indexOf(proxy);
 
-  proxies.splice(proxies.indexOf(proxy), 1);
-  delete processIds[node.processId];
-
-  currProxy = proxies.length - 1;
+  if(idx > -1) {
+    proxies.splice(proxies.indexOf(proxy), 1);
+    delete processIds[node.processId];
+  
+    currProxy = proxies.length - 1;
+  }
 }
 
 // listen for node additions and removals through Redis


### PR DESCRIPTION
`currProxy` variable could be turned into minus, but it happens randomly.

the culprit is that when crashing and then shutting down the server, that unregister function in proxy executed 2 times, and that made the proxy happen to deduct `currProxy` into minus value if there's only 2 proxy for example.