### PR TITLE
fix proxy error ignore rule

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -68,7 +68,7 @@ function register(node: Node) {
     console.error(err.stack);
 
     const errorMessage = err.message.toLowerCase();
-    if(!errorMessage.includes("socket hang up") || !errorMessage.includes("ECONNRESET")) {
+    if(!errorMessage.includes("socket hang up") && !errorMessage.includes("ECONNRESET")) {
       console.warn(`node ${node.processId}/${node.address} failed, unregistering`);
       unregister(node);
       cleanUpNode(node).then(() => console.log(`cleaned up ${node.processId} presence`));

--- a/proxy.ts
+++ b/proxy.ts
@@ -73,7 +73,9 @@ function register(node: Node) {
       unregister(node);
       cleanUpNode(node).then(() => console.log(`cleaned up ${node.processId} presence`));
 
-      reqHandler(req, res); // try again!
+      if (res instanceof http.ServerResponse) {
+        reqHandler(req, res); // try again!
+      }
     } else {
       res.end();
     }


### PR DESCRIPTION
Hi, I spotted an issue in the ignore rule supposed to fix #14.
The unregistration is supposed to happen only when the error is neither `socket hang up` nor `ECONNRESET`, as these are both transient errors.
However, as the code is currently written, unregistration will always happen due to a typo in the condition.