### PR TITLE
Fix connection reset handling

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -68,7 +68,7 @@ function register(node: Node) {
     console.error(err.stack);
 
     const errorMessage = err.message.toLowerCase();
-    if(!errorMessage.includes("socket hang up") && !errorMessage.includes("ECONNRESET")) {
+    if(!errorMessage.includes("socket hang up") && !errorMessage.includes("econnreset")) {
       console.warn(`node ${node.processId}/${node.address} failed, unregistering`);
       unregister(node);
       cleanUpNode(node).then(() => console.log(`cleaned up ${node.processId} presence`));


### PR DESCRIPTION
`errorMessage` is lowercase but we're comparing against an uppercase `ECONNRESET`.